### PR TITLE
Change hardware ID to match Traktor Audio 6

### DIFF
--- a/src/modules/alsa/mixer/profile-sets/90-pulseaudio.rules
+++ b/src/modules/alsa/mixer/profile-sets/90-pulseaudio.rules
@@ -98,7 +98,7 @@ ATTRS{idVendor}=="17cc", ATTRS{idProduct}=="0839", ENV{PULSE_PROFILE_SET}="nativ
 ATTRS{idVendor}=="17cc", ATTRS{idProduct}=="baff", ENV{PULSE_PROFILE_SET}="native-instruments-traktorkontrol-s4.conf"
 ATTRS{idVendor}=="17cc", ATTRS{idProduct}=="4711", ENV{PULSE_PROFILE_SET}="native-instruments-korecontroller.conf"
 ATTRS{idVendor}=="17cc", ATTRS{idProduct}=="041d", ENV{PULSE_PROFILE_SET}="native-instruments-traktor-audio2.conf"
-ATTRS{idVendor}=="17cc", ATTRS{idProduct}=="1011", ENV{PULSE_PROFILE_SET}="native-instruments-traktor-audio6.conf"
+ATTRS{idVendor}=="17cc", ATTRS{idProduct}=="1010", ENV{PULSE_PROFILE_SET}="native-instruments-traktor-audio6.conf"
 ATTRS{idVendor}=="17cc", ATTRS{idProduct}=="1021", ENV{PULSE_PROFILE_SET}="native-instruments-traktor-audio10.conf"
 ATTRS{idVendor}=="0763", ATTRS{idProduct}=="2012", ENV{PULSE_PROFILE_SET}="maudio-fasttrack-pro.conf"
 ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02bb", ENV{PULSE_PROFILE_SET}="kinect-audio.conf"


### PR DESCRIPTION
Every time I reinstall or update Ubuntu I have to make this change to get it to recognise my Native Instruments Traktor Audio 6 external soundcard.

Each time I remember the change by hunting down this forum post in German, https://forum.ubuntuusers.de/topic/traktor-audio-6-erkannt-aber-nicht-anwaehlbar/3/#post-8759808 (I don't speak German).

I'm not sure if the ID is just incorrect or if perhaps the hardware identifies itself differently on slightly different models, so perhaps we need to duplicate the line - I'm well outside of my comfort zone here and I know barely anything about how hardware works on Linux but figured if it helps me it would help others so I should put it forward.

Thanks!